### PR TITLE
Update README.md to show support for PS3/PS4/PS5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ OmniDrive is a firmware modification for MediaTek MT1959-based optical disc driv
 | BD (ROM/R/RE) | ☑️ |
 | BD-XL (R/RE) | ☑️ |
 | UHD-BD | ☑️ |
-| PlayStation 3 BD-ROM | ☑️ |
-| PlayStation 4 BD-ROM | ☑️ |
-| PlayStation 5 BD-ROM | ☑️ |
+| PlayStation 3 BD-ROM | ☑️ | Disc contents are encrypted, disc key is not retrievable
+| PlayStation 4 BD-ROM | ☑️ | Disc contents are encrypted, disc key is not retrievable
+| PlayStation 5 BD-ROM | ☑️ | Disc contents are encrypted, disc key is not retrievable
 | Xbox (XGD1) | ✅ |
 | Xbox 360 (XGD2/XGD3) | ✅ |
 | Xbox One/Series (XGD4) | ✅ |


### PR DESCRIPTION
Flashed the firmware and could dump a copy of gta 5 on ps3, ps4 and ps5 into a .iso file pre and post flashing.
tested on BU40N
